### PR TITLE
Fix(Cliente): impedir cadastro de clientes com CPF duplicado

### DIFF
--- a/assets/styles/app.css
+++ b/assets/styles/app.css
@@ -6,29 +6,29 @@ body {
 }
 
 .sidebar {
-    width: 280px; 
-    position: fixed; 
+    width: 280px;
+    position: fixed;
     top: 0;
     left: 0;
     bottom: 0;
     padding: 1.5rem 1rem;
     background-color: #0B0909;
     color: #fff;
-    overflow-y: auto; 
+    overflow-y: auto;
 }
 
 .main-content {
-    margin-left: 280px; 
-    width: calc(100% - 280px); 
-    
+    margin-left: 280px;
+    width: calc(100% - 280px);
+
     display: flex;
     flex-direction: column;
     min-height: 100vh;
 }
-        
+
 .page-content {
-    padding: 2rem; 
-    flex-grow: 1; 
+    padding: 2rem;
+    flex-grow: 1;
 }
 
 .sidebar .title {
@@ -54,12 +54,42 @@ body {
 }
 
 .btn-laranja {
-    background-color: #FE4A49; 
+    background-color: #FE4A49;
     border-color: #FE4A49;
     color: rgb(255, 255, 255);
 }
+
 .btn-laranja:hover {
     background-color: #852525;
     border-color: #852525;
     color: rgb(0, 0, 0);
+}
+
+.flash-auto-hide {
+    animation: flashHide 5s forwards;
+    overflow: hidden;
+}
+
+@keyframes flashHide {
+    0% {
+        opacity: 1;
+        max-height: 200px;
+        margin-bottom: .5rem;
+        padding-top: .75rem;
+        padding-bottom: .75rem;
+    }
+    80% {
+        opacity: 1;
+        max-height: 200px;
+        margin-bottom: .5rem;
+        padding-top: .75rem;
+        padding-bottom: .75rem;
+    }
+    100% {
+        opacity: 0;
+        max-height: 0;
+        margin-bottom: 0;
+        padding-top: 0;
+        padding-bottom: 0;
+    }
 }

--- a/migrations/Version20251202224029.php
+++ b/migrations/Version20251202224029.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20251202224029 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('CREATE UNIQUE INDEX UNIQ_F41C9B253E3E11F0 ON cliente (cpf)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('DROP INDEX UNIQ_F41C9B253E3E11F0 ON cliente');
+    }
+}

--- a/src/Controller/Cliente/Criar/Controller.php
+++ b/src/Controller/Cliente/Criar/Controller.php
@@ -5,6 +5,7 @@ namespace App\Controller\Cliente\Criar;
 use App\Entity\Cliente;
 use App\Form\ClienteType;
 use App\Service\Cliente\ClienteService;
+use App\Exception\Cliente\CpfJaCadastradoException;
 use App\Exception\Cliente\ClienteInvalidDataException;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
@@ -13,20 +14,11 @@ use Symfony\Component\Routing\Annotation\Route;
 
 class Controller extends AbstractController
 {
-    public function __construct(
-        private ClienteService $clienteService
-    ) {
-    }
-
-    #[Route('/clientes/novo', name: 'clientes_novo', methods: ['GET', 'POST'])]
-    public function novo(Request $request): Response
+    public function __construct(private ClienteService $clienteService) {}
+    #[Route('/clientes/novo', name: 'clientes_novo', methods: ['GET', 'POST'])] public function novo(Request $request): Response
     {
         $cliente = new Cliente();
-
-        $form = $this->createForm(ClienteType::class, $cliente, [
-            'is_edit' => false,
-        ]);
-        
+        $form = $this->createForm(ClienteType::class, $cliente);
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
@@ -34,15 +26,15 @@ class Controller extends AbstractController
                 $this->clienteService->criar($cliente);
                 $this->addFlash('success', 'Cliente cadastrado com sucesso!');
                 return $this->redirectToRoute('clientes_index');
+            } catch (CpfJaCadastradoException $e) {
+                $this->addFlash('danger', 'Já existe um cliente cadastrado com o CPF informado.');
+                return $this->redirectToRoute('clientes_novo');
             } catch (ClienteInvalidDataException $e) {
                 $this->addFlash('danger', $e->getMessage());
             } catch (\Throwable $e) {
                 $this->addFlash('danger', 'Erro ao cadastrar cliente.');
             }
         }
-
-        return $this->render('cliente/new.html.twig', [
-            'form' => $form->createView(),
-        ]);
+        return $this->render('cliente/new.html.twig', ['form' => $form->createView(),]);
     }
 }

--- a/src/Entity/Cliente.php
+++ b/src/Entity/Cliente.php
@@ -20,7 +20,7 @@ class Cliente
     #[ORM\Column(length: 255)]
     private ?string $nome = null;
 
-    #[ORM\Column(length: 255)]
+    #[ORM\Column(length: 255, unique: true)]
     private ?string $cpf = null;
 
     #[ORM\Column(length: 255, nullable: true)]

--- a/src/Exception/Cliente/CpfJaCadastradoException.php
+++ b/src/Exception/Cliente/CpfJaCadastradoException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Exception\Cliente;
+use Exception;
+
+class CpfJaCadastradoException extends Exception
+{
+    public function __construct()
+    {
+        parent::__construct('O CPF informado já está cadastrado.');
+    }
+}

--- a/src/Repository/ClienteRepository.php
+++ b/src/Repository/ClienteRepository.php
@@ -4,6 +4,8 @@ namespace App\Repository;
 
 use App\Entity\Cliente;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
+use App\Exception\Cliente\CpfJaCadastradoException;
 use Doctrine\Persistence\ManagerRegistry;
 
 class ClienteRepository extends ServiceEntityRepository
@@ -15,10 +17,15 @@ class ClienteRepository extends ServiceEntityRepository
 
     public function salvar(Cliente $cliente): void
     {
-        $em = $this->getEntityManager();
+         $em = $this->getEntityManager();
+
+    try {
         $em->persist($cliente);
         $em->flush();
+    } catch (UniqueConstraintViolationException $e) {
+        throw new CpfJaCadastradoException();
     }
+}
 
     public function remover(Cliente $cliente): void
     {
@@ -44,7 +51,7 @@ class ClienteRepository extends ServiceEntityRepository
         }
 
         $cpf = preg_replace('/\D/', '', $busca);
-        
+
         $qb = $this->createQueryBuilder('c')
             ->where('c.nome LIKE :termoGeral')
             ->setParameter('termoGeral', '%' . $busca . '%')

--- a/templates/partials/error-mensage.html.twig
+++ b/templates/partials/error-mensage.html.twig
@@ -1,6 +1,6 @@
 {% for label, messages in app.flashes %}
     {% for message in messages %}
-        <div class="alert alert-{{ label }}">
+        <div class="alert alert-{{ label }} flash-auto-hide">
             {{ message }}
         </div>
     {% endfor %}


### PR DESCRIPTION
Coreção do problema que permitia cadastrar clientes com CPFs duplicados, garantindo a integridade dos dados no módulo de clientes.

**Alterações**

- Ajuste no cadastro para impedir duplicidade de CPF.
- Adicionado tratamento adequado para tentativas de registro duplicado.

<img width="1600" height="676" alt="Captura de tela de 2025-12-06 21-36-02" src="https://github.com/user-attachments/assets/90cb80d7-557f-4e63-bd5b-08ddd67f7dbb" />
